### PR TITLE
downgrade to sdk preview.5

### DIFF
--- a/.github/workflows/ARM.yml
+++ b/.github/workflows/ARM.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Clean previous install
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '10.0.100-preview.5.25277.114'
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,12 @@ jobs:
           mono-version: latest
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <AssemblyCopyright>Copyright (c) 2006-2022 The Contributors of the Python.NET Project</AssemblyCopyright>
     <AssemblyCompany>pythonnet</AssemblyCompany>
     <AssemblyProduct>Python.NET</AssemblyProduct>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <IsPackable>false</IsPackable>
     <FullVersion>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)version.txt").Trim())</FullVersion>
     <VersionPrefix>$(FullVersion.Split('-', 2)[0])</VersionPrefix>
@@ -12,13 +12,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NonCopyableAnalyzer" Version="0.7.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "10.0.100-preview.5.25277.114",
+        "rollForward": "disable"
+    }
+}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,8 +39,8 @@ deployment:
       - ./pythonnet/runtime/Python.Runtime.dll
   -
     type: customized
-    allow_branches: dynamo_py3
+    allow_branches: testnet
     scripts:
-      - dotnet pack --no-build --configuration Release --version-suffix preview-%BUILD_DATE% --output "Release-Preview"
+      - dotnet pack --no-build --configuration Release --version-suffix test-%BUILD_DATE% --output "Release-Preview"
       - dotnet nuget push --source https://api.nuget.org/v3/index.json --api-key %API_KEY% "Release-Preview/**/*.nupkg"
       - dotnet nuget push --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key %API_KEY% "Release-Preview/**/*.snupkg"

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/src/module_tests/Python.ModuleTest.csproj
+++ b/src/module_tests/Python.ModuleTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Pin SDK: Added global.json to use .NET SDK 10.0.100-preview.5.25277.114 with roll-forward disabled.
- Compiler/language: Set <LangVersion>12.0</LangVersion> in Directory.Build.props to compile with C# 12.
- Clean up toolchain: Removed
  - Microsoft.Net.Compilers.Toolset (old Roslyn override), and
  - NonCopyableAnalyzer (was raising “non-copyable” errors).

### Does this close any currently open issues?

Build with the .NET 10 SDK reliably while avoiding C# 13 preview diagnostics and mismatches from an old compiler/analyzer.

### Any other comments?

@zeusongit 

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
